### PR TITLE
Minimize the container's attack surface and the potential impact of a compromise

### DIFF
--- a/evmos/manifests/statefulset.yaml
+++ b/evmos/manifests/statefulset.yaml
@@ -17,17 +17,16 @@ spec:
       containers:
       - name: evmosnode
         securityContext:
-          fsGroup: 0
-          runAsUser: 0
-          runAsGroup: 0
-          allowPrivilegeEscalation: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
           capabilities:
             drop:
             - ALL
-          privileged: true
-          readOnlyRootFilesystem: false # to be changed in prod
-          runAsNonRoot: false
-        image: gregsaram/evmos:15.0.0-rc2-testnet-0.3
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        image: gregsaram/evmos:15.0.0-rc2-testnet-0.5
         resources:
           requests:
             memory: "20Gi"
@@ -51,7 +50,7 @@ spec:
           name: promotheus
         volumeMounts:
         - name: evmos-vol
-          mountPath: /evmos
+          mountPath: /home/evmos
   volumeClaimTemplates:
   - metadata:
       name: evmos-vol

--- a/evmos/tesnet-validator/Dockerfile
+++ b/evmos/tesnet-validator/Dockerfile
@@ -14,8 +14,8 @@ RUN chmod +x /usr/bin/statesync.sh
 COPY snapshot.sh /usr/bin/snapshot.sh
 RUN chmod +x /usr/bin/snapshot.sh
 
-# USER 1000
-WORKDIR /evmos
+USER 1000
+WORKDIR /home/evmos
 
 EXPOSE 26656 26657 1317 9090 8545 8546
 

--- a/evmos/tesnet-validator/snapshot.sh
+++ b/evmos/tesnet-validator/snapshot.sh
@@ -12,7 +12,7 @@ MONIKER="testnetvalidator-gregsio"
 KEYRING="test"
 KEYALGO="eth_secp256k1"
 LOGLEVEL="info"
-HOMEDIR="/evmos/evmosd"
+HOMEDIR="~/.evmosd"
 CONFIGDIR="$HOMEDIR/config"
 DATADIR="$HOMEDIR/data"
 

--- a/evmos/tesnet-validator/statesync.sh
+++ b/evmos/tesnet-validator/statesync.sh
@@ -13,8 +13,7 @@ KEYALGO="eth_secp256k1"
 LOGLEVEL="info"
 
 # Set dedicated home directory for the evmosd instance
-#HOMEDIR="~/.evmosd"
-HOMEDIR="/evmos/evmosd"
+HOMEDIR="~/.evmosd"
 CONFIGDIR="$HOMEDIR/config"
 
 # Path variables

--- a/evmos/tesnet-validator/testnet_node.sh
+++ b/evmos/tesnet-validator/testnet_node.sh
@@ -9,7 +9,7 @@ KEYRING="test"
 KEYALGO="eth_secp256k1"
 LOGLEVEL="info"
 # Set dedicated home directory for the evmosd instance
-HOMEDIR="/evmos/evmosd"
+HOMEDIR="~/.evmosd"
 CONFIGDIR="$HOMEDIR/config"
 
 # to trace evm

--- a/k8s/private-cluster/gke-private.tf
+++ b/k8s/private-cluster/gke-private.tf
@@ -37,7 +37,7 @@ module "gke" {
   master_ipv4_cidr_block     = "10.50.0.0/28"
   master_global_access_enabled = true
   add_cluster_firewall_rules  = true
-  gateway_api_channel         = "CHANNEL_STANDARD" 
+  gateway_api_channel         = "CHANNEL_STANDARD"
 
   # enable in production.
   # master_authorized_networks = [
@@ -50,7 +50,7 @@ module "gke" {
   node_pools = [
     {
       name                      = "default-node-pool"
-      machine_type              = "e2-medium"
+      machine_type              = "n1-standard-8"
       node_locations            = "us-central1-a,us-central1-b"
       min_count                 = 1
       max_count                 = 5


### PR DESCRIPTION
* Restore least-privileges security context
* Minimize the container's attack surface and the potential impact of a compromise
       - prevents processes within the container from gaining additional privileges
      -  restricts from performing operations that require elevated privileges.
      -  ensures that the container is not run in privileged mode
      -  makes the root filesystem of the container read-only
* Update Dockerfile to use evmos user
* Change volume mount to /home/evmos
